### PR TITLE
Centralized the database filename

### DIFF
--- a/Httpy.py
+++ b/Httpy.py
@@ -1,8 +1,8 @@
 import requests
-
+from urllib3 import disable_warnings
 from common import HTTP_PROXY
 
-requests.packages.urllib3.disable_warnings()
+disable_warnings()
 
 DEFAULT_USERAGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:19.0) Gecko/20100101 Firefox/19.0'
 DEFAULT_TIMEOUT = 600

--- a/common.py
+++ b/common.py
@@ -13,4 +13,6 @@ for h in logger.handlers:
 logger.addHandler(file_handler)
 logger.addHandler(StreamHandler(sys.stdout))
 
-HTTP_PROXY="http://localhost:5050"
+HTTP_PROXY = "http://localhost:5050"
+
+DBFILE = r"D:\bigdb\reddit.db"

--- a/common.py
+++ b/common.py
@@ -15,4 +15,4 @@ logger.addHandler(StreamHandler(sys.stdout))
 
 HTTP_PROXY = "http://localhost:5050"
 
-DBFILE = r"D:\bigdb\reddit.db"
+DBFILE = "reddit.db"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pillow
 requests
 flask
 gallery-dl
+urllib3

--- a/scan.py
+++ b/scan.py
@@ -19,7 +19,7 @@ import ReddiWrap
 from DB import DB
 from Httpy import Httpy
 from ImageHash import avhash, create_thumb, image_from_buffer
-from common import logger
+from common import logger, DBFILE
 from img_util import get_image_urls
 from util import load_list, get_links_from_body, should_download_image, is_direct_link, clean_url, \
     should_parse_link
@@ -93,7 +93,7 @@ SCHEMA = {
         'PRIMARY KEY(urlid, postid, commentid)'
     # Prevent a post or comment from having more than two of the same exact image
 }
-db = DB('reddit.db', **SCHEMA)
+db = DB(DBFILE, **SCHEMA)
 
 
 def main():

--- a/search.py
+++ b/search.py
@@ -3,7 +3,7 @@ import re
 from os import path
 
 from flask import Blueprint, Response, request
-
+from common import DBFILE
 from DB import DB
 from Httpy import Httpy
 from ImageHash import avhash, thumb_path, image_from_buffer
@@ -13,7 +13,7 @@ search_page = Blueprint('search', __name__, template_folder='templates')
 
 AlphaNum = re.compile(r'[\W_]+')
 
-db = DB('reddit.db')
+db = DB(DBFILE)
 web = Httpy()
 
 

--- a/status.py
+++ b/status.py
@@ -1,11 +1,11 @@
 import json
 
 from flask import Blueprint, Response
-
+from common import DBFILE
 from ClientDB import DB
 from util import load_list
 
-db = DB('reddit.db')
+db = DB(DBFILE)
 status_page = Blueprint('status', __name__, template_folder='templates')
 
 

--- a/upload.py
+++ b/upload.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import os
-import tempfile
+from common import DBFILE
 
 from flask import Blueprint, Response, request
 
@@ -12,7 +12,7 @@ from scan import try_remove
 from search import get_results_tuple_for_hash
 
 upload_page = Blueprint('upload', __name__, template_folder='templates')
-db = DB('reddit.db')
+db = DB(DBFILE)
 
 
 @upload_page.route("/upload", methods=["POST"])


### PR DESCRIPTION
Minor tweak to simplify moving the database file to a different filesystem, giving it a different name, etc. 

Also tweaked the urllib3 import to directly reference the underlying library and not use the deprecated requests reference.